### PR TITLE
Fixes #2, file:// URLs in Chrome

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -16,7 +16,8 @@
     "permissions": [
 	"activeTab",
 	"clipboardRead",
-	"storage"
+	"storage",
+	"file://*/*"
     ],
 
     "browser_action": {


### PR DESCRIPTION
I didn't realize that this would be an issue on the version published on the Chrome Web Store, so here's a quick fix. Hopefully this doesn't introduce any other complications.