### PR TITLE
Patch to fix deprecated execCommand

### DIFF
--- a/bg/monitor.js
+++ b/bg/monitor.js
@@ -60,15 +60,15 @@ function uninject(id) {
 }
 
 function checkClipboard() {
-    const pasteTarget = document.querySelector("#paste-target")
-    pasteTarget.innerText = ""
-    pasteTarget.focus()
-    document.execCommand("paste")
-    const content = pasteTarget.innerText
-    if(content.trim() !== previousContent.trim() && content != "") {
-	listeningTabs.forEach(id => notifyForeground(id, content))
-	previousContent = content
-    }
+    navigator.clipboard.readText().then((clipText) => {
+        const pasteTarget = document.querySelector("#paste-target")
+        pasteTarget.innerText = clipText
+
+        if (clipText.trim() !== previousContent.trim() && clipText != "") {
+            listeningTabs.forEach(id => notifyForeground(id, clipText))
+            previousContent = clipText
+        }
+    });
 }
 
 function updateTimer() {


### PR DESCRIPTION
`execCommand` seems to be deprecated and **is no longer working** on the latest Firefox release. This patch fixes it by using the newer clipboard API instead.

Notes:
- I haven't tested this out on any browser other than Firefox, but the [caniuse page](https://caniuse.com/mdn-api_navigator_clipboard) shows that it works the latest versions of basically all browsers outside of IE11, so I assume it works.
- With the newer API, I don't think the `paste-target` div is actually needed anymore, but I kept it here just in case.
- I'm leaving the version bumping (in `manifest.json`) up to you.
- Fixes #14 

EDIT: For people who want an updated/rewritten alternative that works on Firefox, see [lap-clipboard-inserter](https://github.com/laplus-sadness/lap-clipboard-inserter).